### PR TITLE
Refactor miniature fragments

### DIFF
--- a/app/src/androidTest/java/ch/epfl/polychef/FullRecipeFragmentTest.java
+++ b/app/src/androidTest/java/ch/epfl/polychef/FullRecipeFragmentTest.java
@@ -24,13 +24,13 @@ public class FullRecipeFragmentTest {
 
     @Test
     public void fragmentIsVisible() {
-        onView(withId(R.id.miniaturesOfflineList)).check(matches(isDisplayed()));
+        onView(withId(R.id.miniatureFragment)).check(matches(isDisplayed()));
     }
 
     @Test
     public void canClickOnFirstElement() {
         onView(withId(R.id.fullRecipeFragment)).check(doesNotExist());
-        onView(withId(R.id.miniaturesOfflineList)).perform(RecyclerViewActions.actionOnItemAtPosition(0, click()));
+        onView(withId(R.id.miniaturesList)).perform(RecyclerViewActions.actionOnItemAtPosition(0, click()));
         onView(withId(R.id.fullRecipeFragment)).check(matches(isDisplayed()));
     }
 }

--- a/app/src/androidTest/java/ch/epfl/polychef/HomePageTest.java
+++ b/app/src/androidTest/java/ch/epfl/polychef/HomePageTest.java
@@ -67,7 +67,7 @@ public class HomePageTest {
 
     @Test
     public void onClickHomeGoesToHome() {
-        testNavButton(R.id.nav_home, R.id.onlineMiniaturesFragment);
+        testNavButton(R.id.nav_home, R.id.miniatureFragment);
     }
 
     @Test

--- a/app/src/androidTest/java/ch/epfl/polychef/OnlineMiniaturesFragmentTest.java
+++ b/app/src/androidTest/java/ch/epfl/polychef/OnlineMiniaturesFragmentTest.java
@@ -116,7 +116,7 @@ public class OnlineMiniaturesFragmentTest {
         fakeRecipeStorage.addRecipe(testRecipe1);
         initActivity();
         wait(1000);
-        onView(withId(R.id.miniaturesOnlineList))
+        onView(withId(R.id.miniaturesList))
                 .perform(RecyclerViewActions.scrollToPosition(getMiniaturesFragment().getRecyclerView().getAdapter().getItemCount() - 1));
         wait(1000);
         assertEquals(1, getMiniaturesFragment().getRecyclerView().getAdapter().getItemCount());
@@ -130,10 +130,10 @@ public class OnlineMiniaturesFragmentTest {
         fakeRecipeStorage.addRecipe(testRecipe1);
         initActivity();
         wait(1000);
-        onView(withId(R.id.miniaturesOnlineList))
+        onView(withId(R.id.miniaturesList))
                 .perform(RecyclerViewActions.scrollToPosition(getMiniaturesFragment().getRecyclerView().getAdapter().getItemCount() - 1));
         wait(1000);
-        onView(ViewMatchers.withId(R.id.miniaturesOnlineList)).perform(ViewActions.swipeUp());
+        onView(ViewMatchers.withId(R.id.miniaturesList)).perform(ViewActions.swipeUp());
         wait(1000);
         assertEquals(OnlineMiniaturesFragment.nbOfRecipesLoadedAtATime + 1, getMiniaturesFragment().getRecyclerView().getAdapter().getItemCount());
     }
@@ -157,19 +157,19 @@ public class OnlineMiniaturesFragmentTest {
 //
 //        initActivity();
 //        wait(1000);
-//        onView(withId(R.id.miniaturesOnlineList))
+//        onView(withId(R.id.miniaturesList))
 //                .perform(RecyclerViewActions.scrollToPosition(getMiniaturesFragment().getRecyclerView().getAdapter().getItemCount() - 1));
 //        wait(4000);
-//        onView(ViewMatchers.withId(R.id.miniaturesOnlineList)).perform(ViewActions.swipeUp());
+//        onView(ViewMatchers.withId(R.id.miniaturesList)).perform(ViewActions.swipeUp());
 //        wait(4000);
-//        onView(withId(R.id.miniaturesOnlineList))
+//        onView(withId(R.id.miniaturesList))
 //                .perform(RecyclerViewActions.scrollToPosition(getMiniaturesFragment().getRecyclerView().getAdapter().getItemCount() - 1));
 //        wait(4000);
-//        onView(ViewMatchers.withId(R.id.miniaturesOnlineList)).perform(ViewActions.swipeUp());
+//        onView(ViewMatchers.withId(R.id.miniaturesList)).perform(ViewActions.swipeUp());
 //        wait(1000);
-//        onView(ViewMatchers.withId(R.id.miniaturesOnlineList)).perform(ViewActions.swipeUp());
+//        onView(ViewMatchers.withId(R.id.miniaturesList)).perform(ViewActions.swipeUp());
 //        wait(1000);
-//        onView(ViewMatchers.withId(R.id.miniaturesOnlineList)).perform(ViewActions.swipeUp());
+//        onView(ViewMatchers.withId(R.id.miniaturesList)).perform(ViewActions.swipeUp());
 //        wait(1000);
 //        assertEquals(OnlineMiniaturesFragment.nbOfRecipesLoadedAtATime * 2 + 1, ((FakeRecipeStorage) fakeRecipeStorage).getRecipeList().size());
 //    }
@@ -183,10 +183,10 @@ public class OnlineMiniaturesFragmentTest {
         fakeRecipeStorage.addRecipe(testRecipe1);
         initActivity();
         wait(1000);
-        onView(withId(R.id.miniaturesOnlineList))
+        onView(withId(R.id.miniaturesList))
                 .perform(RecyclerViewActions.scrollToPosition(getMiniaturesFragment().getRecyclerView().getAdapter().getItemCount() - 1));
         wait(1000);
-        onView(ViewMatchers.withId(R.id.miniaturesOnlineList)).perform(ViewActions.swipeUp());
+        onView(ViewMatchers.withId(R.id.miniaturesList)).perform(ViewActions.swipeUp());
         wait(1000);
         assertEquals(OnlineMiniaturesFragment.nbOfRecipesLoadedAtATime * 2, getMiniaturesFragment().getRecyclerView().getAdapter().getItemCount());
     }

--- a/app/src/main/java/ch/epfl/polychef/fragments/MiniaturesFragment.java
+++ b/app/src/main/java/ch/epfl/polychef/fragments/MiniaturesFragment.java
@@ -1,0 +1,93 @@
+package ch.epfl.polychef.fragments;
+
+
+import android.content.Context;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.Fragment;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import java.util.List;
+
+import ch.epfl.polychef.R;
+import ch.epfl.polychef.adaptersrecyclerview.RecipeMiniatureAdapter;
+import ch.epfl.polychef.recipe.Recipe;
+
+
+public abstract class MiniaturesFragment<T extends AppCompatActivity> extends Fragment {
+
+    protected T hostActivity;  //TODO use ConnectedActivity if possible
+    protected List<Recipe> recipes;
+
+    protected RecyclerView recyclerView;
+
+    public MiniaturesFragment() {
+        // Required empty public constructor
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+
+        View view = inflater.inflate(getLayoutId(), container, false);
+
+        recyclerView = view.findViewById(getRecyclerViewId());
+
+        recyclerView.setLayoutManager(new LinearLayoutManager(this.getActivity()));
+
+        recyclerView.setAdapter(new RecipeMiniatureAdapter(this.getActivity(), recipes, recyclerView, container.getId()));
+
+        // Add a scroll listener when we reach the end of the list we load new recipes from database
+        recyclerView.addOnScrollListener(new RecyclerView.OnScrollListener() {
+            @Override
+            public void onScrollStateChanged(@NonNull RecyclerView recycler, int newState) {
+                super.onScrollStateChanged(recycler, newState);
+
+                updateContent(recycler, newState);
+            }
+        });
+
+        return view;
+    }
+
+    @Override
+    public void onAttach(@NonNull Context context) {
+        super.onAttach(context);
+
+        attachPage(context);
+    }
+
+    public void attachPage(Context context) {
+        throw new IllegalArgumentException("This fragment wasn't attached properly!");
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        initialiseContent();
+    }
+
+    public abstract void updateContent(RecyclerView recycler, int newState);
+    public abstract void initialiseContent();
+
+    public int getRecyclerViewId(){
+        return R.id.miniaturesList;
+    }
+
+    public int getLayoutId(){
+        return R.layout.fragment_miniatures;
+    }
+
+    public RecyclerView getRecyclerView(){
+        return recyclerView;
+    }
+}

--- a/app/src/main/java/ch/epfl/polychef/fragments/OfflineMiniaturesFragment.java
+++ b/app/src/main/java/ch/epfl/polychef/fragments/OfflineMiniaturesFragment.java
@@ -1,7 +1,9 @@
 package ch.epfl.polychef.fragments;
 
+import android.content.Context;
 import android.os.Bundle;
 
+import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -10,29 +12,41 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+
 import ch.epfl.polychef.R;
 import ch.epfl.polychef.adaptersrecyclerview.RecipeMiniatureAdapter;
+import ch.epfl.polychef.pages.EntryPage;
 import ch.epfl.polychef.recipe.OfflineRecipes;
 
-public final class OfflineMiniaturesFragment extends Fragment {
-    private RecyclerView offlineRecyclerView;
+public final class OfflineMiniaturesFragment extends MiniaturesFragment<EntryPage> {
+    //private RecyclerView offlineRecyclerView;
 
     public OfflineMiniaturesFragment() {}
 
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container,
-                             Bundle savedInstanceState) {
-        View view = inflater.inflate(R.layout.fragment_miniatures_offline, container, false);
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        recipes = OfflineRecipes.getInstance().getOfflineRecipes();
+        return super.onCreateView(inflater, container, savedInstanceState);
+    }
 
-        // Get the fragmentID of the container which has this fragment in it
-        Bundle bundle = getArguments();
-        int fragmentID = bundle.getInt("fragmentID");
+    @Override
+    public void updateContent(RecyclerView recycler, int newState) {
 
-        // Instantiate the recyclerView with the adapter and the layout manager
-        offlineRecyclerView = view.findViewById(R.id.miniaturesOfflineList);
-        offlineRecyclerView.setLayoutManager(new LinearLayoutManager(this.getActivity()));
-        offlineRecyclerView.setAdapter(new RecipeMiniatureAdapter(this.getActivity(), OfflineRecipes.getInstance().getOfflineRecipes(), offlineRecyclerView, fragmentID));
+    }
 
-        return view;
+    @Override
+    public void initialiseContent() {
+
+    }
+
+    @Override
+    public void attachPage(Context context) {
+        if(context instanceof EntryPage){
+            hostActivity = (EntryPage) context;
+        } else {
+            super.attachPage(context);
+        }
     }
 }

--- a/app/src/main/java/ch/epfl/polychef/fragments/OnlineMiniaturesFragment.java
+++ b/app/src/main/java/ch/epfl/polychef/fragments/OnlineMiniaturesFragment.java
@@ -1,5 +1,6 @@
 package ch.epfl.polychef.fragments;
 
+import android.content.Context;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -18,14 +19,11 @@ import java.util.List;
 import ch.epfl.polychef.CallNotifier;
 import ch.epfl.polychef.R;
 import ch.epfl.polychef.adaptersrecyclerview.RecipeMiniatureAdapter;
+import ch.epfl.polychef.pages.HomePage;
 import ch.epfl.polychef.recipe.RecipeStorage;
 import ch.epfl.polychef.recipe.Recipe;
 
-public class OnlineMiniaturesFragment extends Fragment implements CallNotifier<Recipe> {
-
-    private RecyclerView onlineRecyclerView;
-
-    private List<Recipe> dynamicRecipeList = new ArrayList<>();
+public class OnlineMiniaturesFragment extends MiniaturesFragment<HomePage> implements CallNotifier<Recipe> {
 
     private int currentReadInt = 1;
 
@@ -36,62 +34,54 @@ public class OnlineMiniaturesFragment extends Fragment implements CallNotifier<R
     private RecipeStorage recipeStorage;
 
     public OnlineMiniaturesFragment(){
-        
+
     }
 
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState){
-        View view = inflater.inflate(R.layout.fragment_miniatures_online, container, false);
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        recipes = new ArrayList<>();
+        return super.onCreateView(inflater, container, savedInstanceState);
+    }
 
-        Bundle bundle = getArguments();
-        recipeStorage = (RecipeStorage) bundle.getSerializable("RecipeStorage");
-
-        int fragmentID = bundle.getInt("fragmentID");
-        onlineRecyclerView = view.findViewById(R.id.miniaturesOnlineList);
-        onlineRecyclerView.setLayoutManager(new LinearLayoutManager(this.getActivity()));
-        onlineRecyclerView.setAdapter(new RecipeMiniatureAdapter(this.getActivity(), dynamicRecipeList, onlineRecyclerView, fragmentID));
-        // Add a scroll listener when we reach the end of the list we load new recipes from database
-        onlineRecyclerView.addOnScrollListener(new RecyclerView.OnScrollListener() {
-            @Override
-            public void onScrollStateChanged(@NonNull RecyclerView recyclerView, int newState) {
-                super.onScrollStateChanged(recyclerView, newState);
-
-                if(!recyclerView.canScrollVertically(1)){
-                    if(isLoading){
-                        return;
-                    }
-                    recipeStorage.getNRecipesOneByOne(nbOfRecipesLoadedAtATime, currentReadInt, OnlineMiniaturesFragment.this);
-                    currentReadInt += nbOfRecipesLoadedAtATime;
-                    isLoading = true;
-                }
+    @Override
+    public void updateContent(RecyclerView recyclerView, int newState){
+        if(!recyclerView.canScrollVertically(1)){
+            if(isLoading){
+                return;
             }
-        });
-        return view;
+            recipeStorage.getNRecipesOneByOne(nbOfRecipesLoadedAtATime, currentReadInt, OnlineMiniaturesFragment.this);
+            currentReadInt += nbOfRecipesLoadedAtATime;
+            isLoading = true;
+        }
     }
 
     @Override
-    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
-        super.onViewCreated(view, savedInstanceState);
+    public void attachPage(Context context) {
+        if(context instanceof HomePage){
+            hostActivity = (HomePage) context;
+            recipeStorage = hostActivity.getRecipeStorage();
+        } else {
+            super.attachPage(context);
+        }
+    }
+
+    @Override
+    public void initialiseContent(){
         // For now when we enter the page we load the offline recipes first
         // add a certain number of recipes at this end of the actual list
-        recipeStorage.getNRecipesOneByOne(nbOfRecipesLoadedAtATime, 1, this);
-        currentReadInt += nbOfRecipesLoadedAtATime;
+        //We ignore the new state
+        updateContent(recyclerView, 0);
     }
 
     @Override
     public void notify(Recipe data) {
         isLoading = false;
-        dynamicRecipeList.add(data);
-        onlineRecyclerView.getAdapter().notifyDataSetChanged();
+        recipes.add(data);
+        recyclerView.getAdapter().notifyDataSetChanged();
     }
 
     @Override
     public void onFailure() {
         isLoading = false;
     }
-
-    public RecyclerView getRecyclerView(){
-        return onlineRecyclerView;
-    }
-
 }

--- a/app/src/main/res/layout/fragment_miniatures.xml
+++ b/app/src/main/res/layout/fragment_miniatures.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/miniatureFragment"
+    tools:context=".fragments.MiniaturesFragment"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:orientation="vertical"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/miniaturesList"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Since multiple fragments will need to display recipe miniatures, this refactoring should help reduce the code duplication: any fragment can implement MiniatureFragment and override a few methods to customise its behavior.